### PR TITLE
fix: support helper and error text outside inset lists

### DIFF
--- a/src/styles/components/ion-list.scss
+++ b/src/styles/components/ion-list.scss
@@ -1,8 +1,12 @@
 @use '../utils/structured-list';
 
-ion-list.md:not(.md3-disabled):not(.list-inset) {
-  padding-top: 0;
-  padding-bottom: 0;
+ion-list.md:not(.md3-disabled) {
+  @include structured-list.support-text;
+
+  &:not(.list-inset) {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
 }
 
 ion-list.md:not(.md3-disabled).list-inset {

--- a/src/styles/utils/structured-list.scss
+++ b/src/styles/utils/structured-list.scss
@@ -1,3 +1,22 @@
+@mixin support-text() {
+  ion-item {
+    &:has(ion-input.input-fill-outline),
+    &:has(ion-textarea.textarea-fill-outline),
+    &:has(ion-select:is([helpertext]:not([helpertext='']), [errortext]:not([errortext='']))),
+    &:has(ion-input .input-bottom > :is(.helper-text:not(:empty), .error-text:not(:empty))),
+    &:has(ion-textarea .textarea-bottom > :is(.helper-text:not(:empty), .error-text:not(:empty))) {
+      --inner-border-width: 0;
+      --inner-padding-bottom: 4px;
+    }
+
+    ion-select .select-bottom:not(:has(> :is(.helper-text:not(:empty), .error-text:not(:empty)))),
+    ion-input .input-bottom:not(:has(> :is(.helper-text:not(:empty), .error-text:not(:empty)))),
+    ion-textarea .textarea-bottom:not(:has(> :is(.helper-text:not(:empty), .error-text:not(:empty)))) {
+      display: none;
+    }
+  }
+}
+
 @mixin layout($outer-note-inset, $group-border-radius) {
   background: transparent;
 
@@ -87,20 +106,6 @@
     }
 
     ion-item {
-      &:has(ion-input.input-fill-outline),
-      &:has(ion-textarea.textarea-fill-outline),
-      &:has(ion-select:is([helpertext]:not([helpertext='']), [errortext]:not([errortext='']))),
-      &:has(ion-input .input-bottom > :is(.helper-text:not(:empty), .error-text:not(:empty))),
-      &:has(ion-textarea .textarea-bottom > :is(.helper-text:not(:empty), .error-text:not(:empty))) {
-        --inner-border-width: 0;
-        --inner-padding-bottom: 4px;
-      }
-      ion-select .select-bottom:not(:has(> :is(.helper-text:not(:empty), .error-text:not(:empty)))),
-      ion-input .input-bottom:not(:has(> :is(.helper-text:not(:empty), .error-text:not(:empty)))),
-      ion-textarea .textarea-bottom:not(:has(> :is(.helper-text:not(:empty), .error-text:not(:empty)))) {
-        display: none;
-      }
-
       &:has(> ion-label:not([slot])):has(> ion-note:not([slot])) {
         &::part(container) {
           flex-direction: column;


### PR DESCRIPTION
## Summary

- extract support-text handling from the inset-only layout mixin
- apply it to every ion-item inside themed ion-list elements
- preserve existing inset-list surface and nested-group styling

This lets input, textarea, and select helper/error areas render correctly in both inset and non-inset lists, including items under reorder, accordion, and radio groups.

## Verification

- npm run build
- Prettier check for the changed SCSS files
- git diff --check
- inspected generated CSS selectors for the non-inset list scope