### PR TITLE
refactor: remove unnecessary important declarations

### DIFF
--- a/src/styles/components/ion-action-sheet.scss
+++ b/src/styles/components/ion-action-sheet.scss
@@ -1,5 +1,5 @@
 ion-action-sheet.md:not(.md3-disabled) {
-  --max-width: 640px !important;
+  --max-width: 640px;
 
   .action-sheet-container {
     overflow: hidden;

--- a/src/styles/components/ion-list.scss
+++ b/src/styles/components/ion-list.scss
@@ -29,9 +29,9 @@ ion-list.md:not(.md3-disabled).list-inset {
       --show-full-highlight: 1;
     }
 
-    &:has(ion-input.input-fill-outline),
-    &:has(ion-textarea.textarea-fill-outline) {
-      --border-width: 0 !important;
+    &:has(:is(ion-input.input-fill-outline, ion-textarea.textarea-fill-outline)):not(.item-lines-inset):not(.item-lines-none),
+    &:has(:is(ion-input.input-fill-outline, ion-textarea.textarea-fill-outline)):is(.item-lines-inset, .item-lines-none) {
+      --border-width: 0;
       --inner-padding-bottom: 4px;
       ion-input,
       ion-textarea {

--- a/src/styles/utils/structured-list.scss
+++ b/src/styles/utils/structured-list.scss
@@ -148,7 +148,7 @@ $groups: ion-item-group, ion-reorder-group, ion-accordion-group, ion-radio-group
           transform: translateY(-7px);
         }
         ion-icon[slot='icon-only'] {
-          font-size: 1.2rem !important;
+          font-size: 1.2rem;
           transform: translateY(4px);
         }
       }


### PR DESCRIPTION
## Summary
- remove all remaining important declarations
- add state-aware item selector specificity where a normal declaration needs to beat the existing line rule
- leave action-sheet and icon declarations as ordinary author styles so downstream users can override them

## Compatibility
- this PR is intentionally stacked on #39 so it contains only important cleanup
- the resulting combined source is identical to the previously reviewed and Mac-verified implementation
- line classes with and without inset or none states remain covered
- no demo-specific selectors or fixture assumptions
- manager and independent acceptance reviews completed with no blocking findings

## Validation
- npm run build
- npm run lint
- git diff --check
- 10 affected Mac Chrome light/dark screenshots matched the before-change baseline

Linux Playwright snapshots were not modified.